### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also get occurrences within a fixed date/time range using the `GetOccurr
 
 ```csharp
 CronExpression expression = CronExpression.Parse("* * * * *");
-DateTime? occurrence = expression.GetOccurrences(
+IEnumerable<DateTime> occurrences = expression.GetOccurrences(
     DateTime.UtcNow,
     DateTime.UtcNow.AddYears(1),
     fromInclusive: true,


### PR DESCRIPTION
Fix typo in README.md

The return value of GetOccurrences should be 'IEnumerable<DateTime>' type, not 'DateTime?'