### PR TITLE
Fix a bug related to rare DST cases because of wrong DateTime convertation between time zones on Windows

### DIFF
--- a/src/Cronos/CronExpression.cs
+++ b/src/Cronos/CronExpression.cs
@@ -211,6 +211,8 @@ namespace Cronos
                 return new DateTime(found, DateTimeKind.Utc);
             }
 
+            fromUtc = DateTimeHelper.FloorToSeconds(fromUtc);
+
             var zonedStart = TimeZoneInfo.ConvertTime(fromUtc, zone);
             var zonedStartOffset = new DateTimeOffset(zonedStart, zonedStart - fromUtc);
             var occurrence = GetOccurrenceByZonedTimes(zonedStartOffset, zone, inclusive);
@@ -253,6 +255,8 @@ namespace Cronos
 
                 return new DateTimeOffset(found, TimeSpan.Zero);
             }
+
+            from = DateTimeHelper.FloorToSeconds(from);
 
             var zonedStart = TimeZoneInfo.ConvertTime(from, zone);
             return GetOccurrenceByZonedTimes(zonedStart, zone, inclusive);

--- a/src/Cronos/DateTimeHelper.cs
+++ b/src/Cronos/DateTimeHelper.cs
@@ -6,19 +6,10 @@ namespace Cronos
     {
         private static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
 
-        public static DateTimeOffset FloorToSeconds(DateTimeOffset dateTimeOffset)
-        {
-            return dateTimeOffset.AddTicks(-GetExtraTicks(dateTimeOffset.Ticks));
-        }
+        public static DateTimeOffset FloorToSeconds(DateTimeOffset dateTimeOffset) => dateTimeOffset.AddTicks(-GetExtraTicks(dateTimeOffset.Ticks));
 
-        public static DateTime FloorToSeconds(DateTime dateTime)
-        {
-            return dateTime.AddTicks(-GetExtraTicks(dateTime.Ticks));
-        }
-        
-        private static long GetExtraTicks(long ticks)
-        {
-            return ticks % OneSecond.Ticks;
-        }
-}
+        public static bool IsRound(DateTimeOffset dateTimeOffset) => GetExtraTicks(dateTimeOffset.Ticks) == 0;
+
+        private static long GetExtraTicks(long ticks) => ticks % OneSecond.Ticks;
+    }
 }

--- a/src/Cronos/DateTimeHelper.cs
+++ b/src/Cronos/DateTimeHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Cronos
+{
+    internal static class DateTimeHelper
+    {
+        private static readonly TimeSpan OneSecond = TimeSpan.FromSeconds(1);
+
+        public static DateTimeOffset FloorToSeconds(DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.AddTicks(-GetExtraTicks(dateTimeOffset.Ticks));
+        }
+
+        public static DateTime FloorToSeconds(DateTime dateTime)
+        {
+            return dateTime.AddTicks(-GetExtraTicks(dateTime.Ticks));
+        }
+        
+        private static long GetExtraTicks(long ticks)
+        {
+            return ticks % OneSecond.Ticks;
+        }
+}
+}

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -2283,6 +2283,35 @@ namespace Cronos.Tests
             Assert.Equal(expectedInstant.UtcDateTime, nextOccurrence);
         }
 
+        [Theory(Timeout = 1000)]
+
+        [InlineData("* * * * * *", "1991-01-01 00:00")]
+        [InlineData("0 * * * * *", "1991-03-02 00:00")]
+        [InlineData("* 0 * * * *", "1991-03-15 00:00")]
+        [InlineData("* * 0 * * *", "1991-03-31 00:00")]
+        [InlineData("* * * 1 * *", "1991-04-15 00:00")]
+        [InlineData("* * * * 1 *", "1991-05-25 00:00")]
+        [InlineData("* * * * * 0", "1991-06-27 00:00")]
+        [InlineData("0 0 0 * * *", "1991-07-16 00:00")]
+        [InlineData("0 0 0 1 * *", "1991-10-30 00:00")]
+        [InlineData("0 0 0 1 1 *", "1991-12-31 00:00")]
+        [InlineData("0 0 0 1 * 1", "1991-12-31 00:00")]
+        public void GetNextOccurrence_MakesProgressInsideLoop(string expression, string fromString)
+        {
+            var cronExpression = CronExpression.Parse(expression, CronFormat.IncludeSeconds);
+
+            var fromInstant = GetInstantFromLocalTime(fromString, EasternTimeZone);
+
+            for (var i = 0; i < 100; i++)
+            {
+                var nextOccurrence = cronExpression.GetNextOccurrence(fromInstant.AddTicks(1), EasternTimeZone, inclusive: true);
+
+                Assert.True(nextOccurrence > fromInstant);
+
+                fromInstant = nextOccurrence.Value;
+            }
+        }
+
         [Theory]
         [InlineData("* * * * *", "2017-03-16 16:00", "2017-03-16 16:01")]
         [InlineData("5 * * * *", "2017-03-16 16:05", "2017-03-16 17:05")]

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -2312,6 +2312,17 @@ namespace Cronos.Tests
             }
         }
 
+        [Fact]
+        public void GetNextOccurrence_ReturnsAGreaterValue_EvenWhenMillisecondTruncationRuleIsAppliedDueToDST()
+        {
+            var expression = CronExpression.Parse("* * * * * *", CronFormat.IncludeSeconds);
+            var fromInstant = DateTimeOffset.Parse("2021-03-25 23:59:59.9999999 +02:00");
+
+            var nextInstant = expression.GetNextOccurrence(fromInstant, JordanTimeZone, inclusive: true);
+
+            Assert.True(nextInstant > fromInstant);
+        }
+
         [Theory]
         [InlineData("* * * * *", "2017-03-16 16:00", "2017-03-16 16:01")]
         [InlineData("5 * * * *", "2017-03-16 16:05", "2017-03-16 17:05")]

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -1141,7 +1141,7 @@ namespace Cronos.Tests
         [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9000000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
 
         [InlineData("30 0 L  * *", "2017-03-31 01:00:00.0000001 +02:00", "2017-04-30 00:30:00 +03:00", true)]
-        public void GetNextOccurrence_HandleDST_WhenTheClockJumpsForward_And_FromIsAroundDST(string cronExpression, string fromString, string expectedString, bool inclusive)
+        public void GetNextOccurrence_HandleDST_WhenTheClockJumpsForwardAndFromIsAroundDST(string cronExpression, string fromString, string expectedString, bool inclusive)
         {
             var expression = CronExpression.Parse(cronExpression);
 
@@ -1149,6 +1149,25 @@ namespace Cronos.Tests
             var expectedInstant = GetInstant(expectedString);
 
             var executed = expression.GetNextOccurrence(fromInstant, JordanTimeZone, inclusive);
+
+            Assert.Equal(expectedInstant, executed);
+            Assert.Equal(expectedInstant.Offset, executed?.Offset);
+        }
+
+        [Theory]
+        [InlineData("0  7 * * *", "2020-05-20 07:00:00.0000001 -04:00", "2020-05-21 07:00:00 -04:00", true)]
+        [InlineData("0  7 * * *", "2020-05-20 07:00:00.0000001 -04:00", "2020-05-21 07:00:00 -04:00", false)]
+
+        [InlineData("0  7 * * *", "2023-08-12 07:00:00.9999999 -04:00", "2023-08-13 07:00:00 -04:00", true)]
+        [InlineData("0  7 * * *", "2023-08-12 07:00:00.9999999 -04:00", "2023-08-13 07:00:00 -04:00", false)]
+        public void GetNextOccurrence_ReturnsCorrectDate_WhenFromIsNotRoundAndZoneIsSpecified(string cronExpression, string fromString, string expectedString, bool inclusive)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+
+            var fromInstant = GetInstant(fromString);
+            var expectedInstant = GetInstant(expectedString);
+
+            var executed = expression.GetNextOccurrence(fromInstant, EasternTimeZone, inclusive);
 
             Assert.Equal(expectedInstant, executed);
             Assert.Equal(expectedInstant.Offset, executed?.Offset);

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -1147,6 +1147,7 @@ namespace Cronos.Tests
         [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9990000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
         [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9900000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
         [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9000000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
+        [InlineData("30 0 L  * *", "2017-03-30 23:59:59.0000000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
 
         [InlineData("30 0 L  * *", "2017-03-31 01:00:00.0000001 +02:00", "2017-04-30 00:30:00 +03:00", true)]
         public void GetNextOccurrence_HandleDST_WhenTheClockJumpsForwardAndFromIsAroundDST(string cronExpression, string fromString, string expectedString, bool inclusive)
@@ -1164,17 +1165,18 @@ namespace Cronos.Tests
 
         [Theory]
 
-        // 2021-04-04 00:00 is time in Chile Time Zone when the clock jumps backward
-        // from 2021-04-03 23:59:59.9999999 -03:00 standard time (ST) to 2021-04-03 23:00:00.0000000 am -04:00 DST .
+        // 2017-05-14 00:00 is time in Chile Time Zone when the clock jumps backward
+        // from 2017-05-13 23:59:59.9999999 -03:00 standard time (ST) to 2017-05-13 23:00:00.0000000 am -04:00 DST .
         // ________23:59:59.9999999 -03:00 ST -> 23:00:00.0000000 -04:00 DST
 
-        [InlineData("30 23 * * *", "2021-04-03 23:59:59.9999999 -03:00", "2021-04-04 23:30:00 -04:00", false)]
-        [InlineData("30 23 * * *", "2021-04-03 23:59:59.9999000 -03:00", "2021-04-04 23:30:00 -04:00", false)]
-        [InlineData("30 23 * * *", "2021-04-03 23:59:59.9990000 -03:00", "2021-04-04 23:30:00 -04:00", false)]
-        [InlineData("30 23 * * *", "2021-04-03 23:59:59.9900000 -03:00", "2021-04-04 23:30:00 -04:00", false)]
-        [InlineData("30 23 * * *", "2021-04-03 23:59:59.9000000 -03:00", "2021-04-04 23:30:00 -04:00", false)]
+        [InlineData("30 23 * * *", "2017-05-13 23:59:59.9999999 -03:00", "2017-05-14 23:30:00 -04:00", false)]
+        [InlineData("30 23 * * *", "2017-05-13 23:59:59.9999000 -03:00", "2017-05-14 23:30:00 -04:00", false)]
+        [InlineData("30 23 * * *", "2017-05-13 23:59:59.9990000 -03:00", "2017-05-14 23:30:00 -04:00", false)]
+        [InlineData("30 23 * * *", "2017-05-13 23:59:59.9900000 -03:00", "2017-05-14 23:30:00 -04:00", false)]
+        [InlineData("30 23 * * *", "2017-05-13 23:59:59.9000000 -03:00", "2017-05-14 23:30:00 -04:00", false)]
+        [InlineData("30 23 * * *", "2017-05-13 23:59:59.0000000 -03:00", "2017-05-14 23:30:00 -04:00", false)]
 
-        [InlineData("30 23 * * *", "2021-04-04 00:00:00.0000001 -04:00", "2021-04-04 23:30:00 -04:00", true)]
+        [InlineData("30 23 * * *", "2017-05-14 00:00:00.0000001 -04:00", "2017-05-14 23:30:00 -04:00", true)]
         public void GetNextOccurrence_HandleDST_WhenTheClockJumpsBackwardAndFromIsAroundDST(string cronExpression, string fromString, string expectedString, bool inclusive)
         {
             var expression = CronExpression.Parse(cronExpression);

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -1134,6 +1134,28 @@ namespace Cronos.Tests
 
         [Theory]
 
+        [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9999999 +02:00", "2017-03-31 01:00:00 +03:00", false)]
+        [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9999000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
+        [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9990000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
+        [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9900000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
+        [InlineData("30 0 L  * *", "2017-03-30 23:59:59.9000000 +02:00", "2017-03-31 01:00:00 +03:00", false)]
+
+        [InlineData("30 0 L  * *", "2017-03-31 01:00:00.0000001 +02:00", "2017-04-30 00:30:00 +03:00", true)]
+        public void GetNextOccurrence_HandleDST_WhenTheClockJumpsForward_And_FromIsAroundDST(string cronExpression, string fromString, string expectedString, bool inclusive)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+
+            var fromInstant = GetInstant(fromString);
+            var expectedInstant = GetInstant(expectedString);
+
+            var executed = expression.GetNextOccurrence(fromInstant, JordanTimeZone, inclusive);
+
+            Assert.Equal(expectedInstant, executed);
+            Assert.Equal(expectedInstant.Offset, executed?.Offset);
+        }
+
+        [Theory]
+
         // 2017-10-01 is date when the clock jumps forward from 1:59 am +10:30 standard time (ST) to 2:30 am +11:00 DST on Lord Howe.
         // ________1:59 ST///invalid///2:30 DST________
 
@@ -2788,6 +2810,7 @@ namespace Cronos.Tests
                 {
                     "yyyy-MM-dd HH:mm:ss zzz",
                     "yyyy-MM-dd HH:mm zzz",
+                    "yyyy-MM-dd HH:mm:ss.fffffff zzz"
                 },
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.None);

--- a/tests/Cronos.Tests/DateTimeHelperFacts.cs
+++ b/tests/Cronos.Tests/DateTimeHelperFacts.cs
@@ -57,8 +57,8 @@ namespace Cronos.Tests
         [InlineData("2021-04-19 01:45:45.1000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
         public void FloorToSeconds_WorksCorrectlyWithDateTimeUtc(string dateTime, string expected, DateTimeKind kind)
         {
-            var dateTimeInstant = GetDateTimeUtcInstant(dateTime, kind);
-            var expectedDateTimeInstant = GetDateTimeUtcInstant(expected, kind);
+            var dateTimeInstant = GetDateTimeInstant(dateTime, kind);
+            var expectedDateTimeInstant = GetDateTimeInstant(expected, kind);
 
             var flooredDateTime = DateTimeHelper.FloorToSeconds(dateTimeInstant);
 
@@ -82,7 +82,7 @@ namespace Cronos.Tests
             return dateTime;
         }
 
-        private static DateTime GetDateTimeUtcInstant(string dateTimeString, DateTimeKind kind)
+        private static DateTime GetDateTimeInstant(string dateTimeString, DateTimeKind kind)
         {
             dateTimeString = dateTimeString.Trim();
 

--- a/tests/Cronos.Tests/DateTimeHelperFacts.cs
+++ b/tests/Cronos.Tests/DateTimeHelperFacts.cs
@@ -36,36 +36,6 @@ namespace Cronos.Tests
             Assert.Equal(expectedDateTimeOffset.Offset, flooredDateTimeOffset.Offset);
         }
 
-        [Theory]
-
-        [InlineData("2021-04-19 01:45:45.0000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-
-        [InlineData("2021-04-19 01:45:45.9000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-        [InlineData("2021-04-19 01:45:45.9900000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-        [InlineData("2021-04-19 01:45:45.9990000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-        [InlineData("2021-04-19 01:45:45.9999000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-        [InlineData("2021-04-19 01:45:45.9999900", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-        [InlineData("2021-04-19 01:45:45.9999990", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-        [InlineData("2021-04-19 01:45:45.9999999", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
-
-        [InlineData("2021-04-19 01:45:45.0000001", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        [InlineData("2021-04-19 01:45:45.0000010", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        [InlineData("2021-04-19 01:45:45.0000100", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        [InlineData("2021-04-19 01:45:45.0001000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        [InlineData("2021-04-19 01:45:45.0010000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        [InlineData("2021-04-19 01:45:45.0100000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        [InlineData("2021-04-19 01:45:45.1000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
-        public void FloorToSeconds_WorksCorrectlyWithDateTimeUtc(string dateTime, string expected, DateTimeKind kind)
-        {
-            var dateTimeInstant = GetDateTimeInstant(dateTime, kind);
-            var expectedDateTimeInstant = GetDateTimeInstant(expected, kind);
-
-            var flooredDateTime = DateTimeHelper.FloorToSeconds(dateTimeInstant);
-
-            Assert.Equal(expectedDateTimeInstant, flooredDateTime);
-            Assert.Equal(expectedDateTimeInstant.Kind, flooredDateTime.Kind);
-        }
-
         private static DateTimeOffset GetDateTimeOffsetInstant(string dateTimeOffsetString)
         {
             dateTimeOffsetString = dateTimeOffsetString.Trim();

--- a/tests/Cronos.Tests/DateTimeHelperFacts.cs
+++ b/tests/Cronos.Tests/DateTimeHelperFacts.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Globalization;
+using Xunit;
+
+namespace Cronos.Tests
+{
+    public class DateTimeHelperFacts
+    {
+        [Theory]
+
+        [InlineData("2017-03-30 23:59:59.0000000 +02:00", "2017-03-30 23:59:59.0000000 +02:00")]
+
+        [InlineData("2017-03-30 23:59:59.9000000 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+        [InlineData("2017-03-30 23:59:59.9900000 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+        [InlineData("2017-03-30 23:59:59.9990000 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+        [InlineData("2017-03-30 23:59:59.9999000 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+        [InlineData("2017-03-30 23:59:59.9999900 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+        [InlineData("2017-03-30 23:59:59.9999990 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+        [InlineData("2017-03-30 23:59:59.9999999 +03:00", "2017-03-30 23:59:59.0000000 +03:00")]
+
+        [InlineData("2017-03-30 23:59:59.0000001 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        [InlineData("2017-03-30 23:59:59.0000010 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        [InlineData("2017-03-30 23:59:59.0000100 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        [InlineData("2017-03-30 23:59:59.0001000 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        [InlineData("2017-03-30 23:59:59.0010000 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        [InlineData("2017-03-30 23:59:59.0100000 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        [InlineData("2017-03-30 23:59:59.1000000 +01:00", "2017-03-30 23:59:59.0000000 +01:00")]
+        public void FloorToSeconds_WorksCorrectlyWithDateTimeOffset(string dateTime, string expected)
+        {
+            var dateTimeOffset = GetDateTimeOffsetInstant(dateTime);
+            var expectedDateTimeOffset = GetDateTimeOffsetInstant(expected);
+
+            var flooredDateTimeOffset = DateTimeHelper.FloorToSeconds(dateTimeOffset);
+
+            Assert.Equal(expectedDateTimeOffset, flooredDateTimeOffset);
+            Assert.Equal(expectedDateTimeOffset.Offset, flooredDateTimeOffset.Offset);
+        }
+
+        [Theory]
+
+        [InlineData("2021-04-19 01:45:45.0000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+
+        [InlineData("2021-04-19 01:45:45.9000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+        [InlineData("2021-04-19 01:45:45.9900000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+        [InlineData("2021-04-19 01:45:45.9990000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+        [InlineData("2021-04-19 01:45:45.9999000", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+        [InlineData("2021-04-19 01:45:45.9999900", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+        [InlineData("2021-04-19 01:45:45.9999990", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+        [InlineData("2021-04-19 01:45:45.9999999", "2021-04-19 01:45:45.0000000", DateTimeKind.Utc)]
+
+        [InlineData("2021-04-19 01:45:45.0000001", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        [InlineData("2021-04-19 01:45:45.0000010", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        [InlineData("2021-04-19 01:45:45.0000100", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        [InlineData("2021-04-19 01:45:45.0001000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        [InlineData("2021-04-19 01:45:45.0010000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        [InlineData("2021-04-19 01:45:45.0100000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        [InlineData("2021-04-19 01:45:45.1000000", "2021-04-19 01:45:45.0000000", DateTimeKind.Unspecified)]
+        public void FloorToSeconds_WorksCorrectlyWithDateTimeUtc(string dateTime, string expected, DateTimeKind kind)
+        {
+            var dateTimeInstant = GetDateTimeUtcInstant(dateTime, kind);
+            var expectedDateTimeInstant = GetDateTimeUtcInstant(expected, kind);
+
+            var flooredDateTime = DateTimeHelper.FloorToSeconds(dateTimeInstant);
+
+            Assert.Equal(expectedDateTimeInstant, flooredDateTime);
+            Assert.Equal(expectedDateTimeInstant.Kind, flooredDateTime.Kind);
+        }
+
+        private static DateTimeOffset GetDateTimeOffsetInstant(string dateTimeOffsetString)
+        {
+            dateTimeOffsetString = dateTimeOffsetString.Trim();
+
+            var dateTime = DateTimeOffset.ParseExact(
+                dateTimeOffsetString,
+                new[]
+                {
+                    "yyyy-MM-dd HH:mm:ss.fffffff zzz",
+                },
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None);
+
+            return dateTime;
+        }
+
+        private static DateTime GetDateTimeUtcInstant(string dateTimeString, DateTimeKind kind)
+        {
+            dateTimeString = dateTimeString.Trim();
+
+            var dateTime = DateTime.ParseExact(
+                dateTimeString,
+                new[]
+                {
+                    "yyyy-MM-dd HH:mm:ss.fffffff",
+                },
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None);
+
+            dateTime = DateTime.SpecifyKind(dateTime, kind);
+
+            return dateTime;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes rare case reproduced on Windows and related to [daylight saving time (DST)](https://en.wikipedia.org/wiki/Daylight_saving_time) transiton.

## DateTime convertation bug on Windows

There are 49 of 141 Windows time zones which have not totally accurate daylight transtion time information. 

Consider time zone **Chile Time** (Windows time zone id: *Pacific SA Standard Time*) as example. Chile Standard Time (CST) is 4 hours before UTC, and  Chile Summer Time (CLST) - 3 hours before UTC.

### 1. DST start case for Chile time zone.

In 2021 DST starts when clocks jump forward from *2021-09-05 00:00 -4:00 CST* to *2021-09-05 01:00 -3:00 CLST*. 
So local time `[2021-09-05 00:00, 2021-09-05 01:00)` does not exist.

time -> _____23:59:59.9999999 -04:00 CST////invalid////01:00:00.0000000 -03:00 CLST

But in Windows time zone data base transition time is not `00:00:00` but `23:59:59.9990000` - 10000 ticks before. 
As as result, convertation from *2021-09-05 03:59:59.9990000 UTC* to Chile time equals *2021-09-05 00:59:59.9990000 -3:00 CLST* instead of *2021-09-04 23:59:59.9990000 -4:00 CST*. See code below:

```csharp
var chileTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific SA Standard Time");

var utcTime = DateTime.Parse("2021-09-05 03:59:59.9990000"); // 23:59:59.999000 local time
var result = TimeZoneInfo.ConvertTimeFromUtc(utcTime, chileTimeZone);
// result equals 2021-09-05 00:59:59.9990000 -3:00 CLST instead of 2021-09-05 23:59:59.9990000 -4:00 CST
```

### 2. DST end case for Chile time zone.

It's the similar behavior for DST end. Clocks jump backward from *2021-04-04 00:00 -3:00 CLST* to *2021-04-03 23:00 -4:00 CLT*. 
So local time `[2021-04-03 23:00, 2021-04-04 00:00)` is ambiguous.

time -> ____23:00 -03:00____23:59:59.9999999 -03:00 CST -> 23:00:00.0000000 -04:00 CLST

And convertation from *2021-04-04 02:59:59.9990000 UTC* to Chile time equals *2021-04-04 22:59:59.9990000 -4:00 CLT* instead of *2021-04-04 23:59:59.9990000 -3:00 CST*.

## Consequences for Cronos

Due to these rounding errors Cronos can skip some occurrences when DST starts:

```csharp
var chileTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific SA Standard Time");
var cronExpression = CronExpression.Parse("30 0 * * *"); // every day at 0:30 am

// 1 tick before DST start, local time 23:59:59.9999999
var fromUtc = DateTimeOffset.Parse("2021-09-05 03:59:59.9999999Z"); 

var next = cronExpression.GetNextOccurrence(fromUtc, chileTimeZone);
// next = "2021-09-06 00:30" instead of "2021-09-05 01:00"
// Occurence skipped on 2021-09-05.
```

Or even get occurrence from the past when DST ends:

```csharp
var chileTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific SA Standard Time");
var cronExpression = CronExpression.Parse("0 23 * * *"); // every day at 23:00 am

// 1 tick before DST end, local time 2021-04-03 23:59:59.9999999 -03:00
var fromUtc = DateTimeOffset.Parse("2021-04-04 02:59:59.9999999Z"); 

var next = cronExpression.GetNextOccurrence(fromUtc, chileTimeZone);
// next = "2021-04-03 23:00 -03:00" instead of "2021-04-04 23:00 -04:00"
// Occurence 2021-04-03 23:00:00.0000000 -03:00 is earlier than fromUtc: 2021-04-03 23:59:59.9999999 -03:00.
```

## Decision

We can just floor input time to seconds and avoid such behavior.

In case of DST start we floor *2021-09-05 03:59:59.9990000 UTC* to *2021-09-05 03:59:59.0000000 UTC*.
Then convertation from *2021-09-05 03:59:59.0000000 UTC* to Chile time equals *2021-09-04 23:59:59.0000000 -4:00 CST* instead of wrong *2021-09-05 00:59:59.9990000 -3:00 CLST*. 

Also we have to set `inclusive = false`. Otherwise floored time can match cron expression and be returned as result, but it'l be wrong because result will be less than passed from argument.