### PR TITLE
Fixed bug finding occurrence with 0 ticks.

### DIFF
--- a/src/Cronos/CronExpression.cs
+++ b/src/Cronos/CronExpression.cs
@@ -34,7 +34,7 @@ namespace Cronos
     /// </summary>
     public sealed class CronExpression: IEquatable<CronExpression>
     {
-        private const long NotFound = 0;
+        private const long NotFound = -1;
         private const int MaxYear = 2499;
 
         /// <summary>

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -2457,6 +2457,18 @@ namespace Cronos.Tests
         }
 
         [Fact]
+        public void GetNextOccurrence_FromDateTimeMinValueInclusive_SuccessfullyReturned()
+        {
+            var expression = CronExpression.Parse("* * * * *");
+            var from = new DateTime(0, DateTimeKind.Utc);
+
+            var occurrence = expression
+                .GetNextOccurrence(from, inclusive: true);
+
+            Assert.Equal(from, occurrence);
+        }
+
+        [Fact]
         public void GetOccurrence_PassesTests_DefinedInTheGitHubIssue53()
         {
             var jan1St2000 = new DateTimeOffset(2000, 01, 01, 00, 00, 00, new TimeSpan(-5, 0, 0));
@@ -2739,6 +2751,20 @@ namespace Cronos.Tests
 
             Assert.Equal(3, occurrences.Length);
             Assert.Equal(from.AddMinutes(2), occurrences[2].UtcDateTime);
+        }
+
+        [Fact]
+        public void GetOccurrences_OccurrenceAtDateTimeMinValue_SuccessfullyReturned()
+        {
+            var expression = CronExpression.Parse("* * * * *");
+            var from = new DateTime(0, DateTimeKind.Utc);
+
+            var occurrences = expression
+                .GetOccurrences(from, from.AddSeconds(1), fromInclusive: true)
+                .ToArray();
+
+            Assert.Single(occurrences);
+            Assert.Equal(from, occurrences[0]);
         }
 
         [Theory]


### PR DESCRIPTION
Fixing issue [GetOccurrences doesn't work for new DateTime(0, DateTimeKind.Utc) #76](https://github.com/HangfireIO/Cronos/issues/76). By changing `NotFound` to -1.
Unit tests added for both `GetNextOccurrence` and `GetOccurrences`.