### PR TITLE
Make CronExpression equality operators accept null without triggering nullable warnings

### DIFF
--- a/src/Cronos/CronExpression.cs
+++ b/src/Cronos/CronExpression.cs
@@ -406,12 +406,12 @@ namespace Cronos
         /// <summary>
         /// Implements the operator ==.
         /// </summary>
-        public static bool operator ==(CronExpression left, CronExpression right) => Equals(left, right);
+        public static bool operator ==(CronExpression? left, CronExpression? right) => Equals(left, right);
 
         /// <summary>
         /// Implements the operator !=.
         /// </summary>
-        public static bool operator !=(CronExpression left, CronExpression right) => !Equals(left, right);
+        public static bool operator !=(CronExpression? left, CronExpression? right) => !Equals(left, right);
 
         private DateTimeOffset? GetOccurrenceConsideringTimeZone(DateTimeOffset fromUtc, TimeZoneInfo zone, bool inclusive)
         {

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -517,7 +517,7 @@ namespace Cronos.Tests
             var result = CronExpression.TryParse("* * * * *", out var cron);
 
             Assert.True(result);
-            Assert.Equal(Today.AddMinutes(1), cron.GetNextOccurrence(Today));
+            Assert.Equal(Today.AddMinutes(1), cron!.GetNextOccurrence(Today));
         }
 
         [Fact]
@@ -542,7 +542,7 @@ namespace Cronos.Tests
             var result = CronExpression.TryParse("* * * * * *", CronFormat.IncludeSeconds, out var cron);
 
             Assert.True(result);
-            Assert.Equal(Today.AddSeconds(1), cron.GetNextOccurrence(Today));
+            Assert.Equal(Today.AddSeconds(1), cron!.GetNextOccurrence(Today));
         }
 
         [Theory]
@@ -2785,6 +2785,7 @@ namespace Cronos.Tests
 
             Assert.False(cronExpression.Equals(null));
             Assert.False(cronExpression == null);
+            Assert.True(cronExpression != null);
         }
 
         [Theory]

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,6 +2,8 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     <PropertyGroup>
         <SignAssembly>true</SignAssembly><!-- InernalsVisibleTo requires test assemblies to be signed too -->
+        <Nullable>enable</Nullable>
+        <WarningsAsErrors>Nullable</WarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Since commit [666db5c](https://github.com/HangfireIO/Cronos/commit/666db5c7725320ab2e9e52667fe2c0d5f78db9da#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907R11) shipped in version 0.11.0, a `CronExpression` can no longer be compared with `null` using the overloaded equality operators without a [CS8625](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-null-assigned-to-a-nonnullable-reference:~:text=possibly%20null%20value.-,CS8625%20%2D%20Cannot%20convert%20null%20literal%20to%20non%2Dnullable%20reference%20type.) nullable warning being produced. The following code shows the issue:
```csharp
CronExpression? a = /* A CronExpression that may or may not be null. */;
if (a != null) { // <-- This line triggers CS8625: Cannot convert null literal to non-nullable reference type
    // [...]
}
```

This PR modifies the overloaded equality operators' arguments nullability to accept null values in order to make the previous example compile without warnings.

@odinserj: I also took the liberty to enable NRT annotation/checking in the `Directory.Build.props` of the `tests` folder (and treat all nullability-related warnings as errors) to align it with the `src` folder's one. I tested it and as expected, without the other changes introduced by this PR, the unit tests would not compile anymore. Let me know whether you want to keep it this way or not.