### PR TITLE
Add support for retrieving previous occurrences in Cron expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ PM> Install-Package Cronos
 
 We've tried to do our best to make Cronos API as simple and predictable in corner cases as possible. So you can only use `DateTime` with `DateTimeKind.Utc` specified (for example, `DateTime.UtcNow`), or `DateTimeOffset` classes to calculate next occurrences. You **cannot use** local `DateTime` objects (such as `DateTime.Now`), because this may lead to ambiguity during DST transitions, and an exception will be thrown if you attempt to use them.
 
-To calculate the next occurrence, you need to create an instance of the `CronExpression` class, and call its `GetNextOccurrence` method. To learn about Cron format, please refer to the next section.
+To calculate the next occurrence, you need to create an instance of the `CronExpression` class, and call its `GetNextOccurrence` method. To search in reverse, use the `GetPreviousOccurrence` method. To learn about Cron format, please refer to the next section.
 
 ```csharp
 using Cronos;
@@ -46,9 +46,10 @@ using Cronos;
 CronExpression expression = CronExpression.Parse("* * * * *");
 
 DateTime? nextUtc = expression.GetNextOccurrence(DateTime.UtcNow);
+DateTime? previousUtc = expression.GetPreviousOccurrence(DateTime.UtcNow);
 ```
 
-The `nextUtc` will contain the next occurrence in UTC, *after the given time*, or `null` value when it is unreachable (for example, Feb 30). If an invalid Cron expression is given, the `CronFormatException` exception is thrown.
+The `nextUtc` will contain the next occurrence in UTC, *after the given time*, or `null` value when it is unreachable (for example, Feb 30). The `previousUtc` will contain the most recent occurrence in UTC, *before the given time*, or `null` when nothing exists. If an invalid Cron expression is given, the `CronFormatException` exception is thrown.
 
 ### Working with time zones
 
@@ -60,6 +61,8 @@ TimeZoneInfo easternTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Stan
 
 DateTime?       next = expression.GetNextOccurrence(DateTime.UtcNow, easternTimeZone);
 DateTimeOffset? next = expression.GetNextOccurrence(DateTimeOffset.UtcNow, easternTimeZone);
+DateTime?       previous = expression.GetPreviousOccurrence(DateTime.UtcNow, easternTimeZone);
+DateTimeOffset? previous = expression.GetPreviousOccurrence(DateTimeOffset.UtcNow, easternTimeZone);
 ```
 
 If you passed a `DateTime` object, resulting time will be in UTC. If you used `DateTimeOffset`, resulting object will contain the **correct offset**, so don't forget to use it especially during DST transitions (see below).
@@ -97,7 +100,17 @@ IEnumerable<DateTime> occurrences = expression.GetOccurrences(
     toInclusive: false);
 ```
 
-There are different overloads for this method to support `DateTimeOffset` arguments or time zones.
+To enumerate matches in reverse order, use the `GetOccurrencesDescending` method. The descending overloads treat the `from` argument as the upper bound and the `to` argument as the lower bound.
+
+```csharp
+IEnumerable<DateTime> previousOccurrences = expression.GetOccurrencesDescending(
+    DateTime.UtcNow,
+    DateTime.UtcNow.AddDays(-7),
+    fromInclusive: true,
+    toInclusive: false);
+```
+
+There are different overloads for these methods to support `DateTimeOffset` arguments or time zones.
 
 ## Cron format
 

--- a/benchmarks/Cronos.Benchmarks/CronBenchmarks.cs
+++ b/benchmarks/Cronos.Benchmarks/CronBenchmarks.cs
@@ -144,9 +144,21 @@ namespace Cronos.Benchmarks
         }
 
         [Benchmark]
+        public DateTime? PreviousSimpleDateTime()
+        {
+            return SimpleExpression.GetPreviousOccurrence(DateTimeNow);
+        }
+
+        [Benchmark]
         public DateTime? NextComplexDateTime()
         {
             return ComplexExpression.GetNextOccurrence(DateTimeNow);
+        }
+
+        [Benchmark]
+        public DateTime? PreviousComplexDateTime()
+        {
+            return ComplexExpression.GetPreviousOccurrence(DateTimeNow);
         }
 
         [Benchmark]
@@ -156,9 +168,21 @@ namespace Cronos.Benchmarks
         }
 
         [Benchmark]
+        public DateTimeOffset? PreviousSimpleDateTimeOffset()
+        {
+            return SimpleExpression.GetPreviousOccurrence(DateTimeOffsetNow, UtcTimeZone);
+        }
+
+        [Benchmark]
         public DateTimeOffset? NextComplexDateTimeOffset()
         {
             return ComplexExpression.GetNextOccurrence(DateTimeOffsetNow, UtcTimeZone);
+        }
+
+        [Benchmark]
+        public DateTimeOffset? PreviousComplexDateTimeOffset()
+        {
+            return ComplexExpression.GetPreviousOccurrence(DateTimeOffsetNow, UtcTimeZone);
         }
 
         [Benchmark]
@@ -168,15 +192,34 @@ namespace Cronos.Benchmarks
         }
 
         [Benchmark]
+        public DateTime? PreviousSimpleWithTimeZone()
+        {
+            return SimpleExpression.GetPreviousOccurrence(DateTimeNow, PacificTimeZone);
+        }
+
+        [Benchmark]
         public DateTime? NextComplexWithTimeZone()
         {
             return ComplexExpression.GetNextOccurrence(DateTimeNow, PacificTimeZone);
         }
 
         [Benchmark]
+        public DateTime? PreviousComplexWithTimeZone()
+        {
+            return ComplexExpression.GetPreviousOccurrence(DateTimeNow, PacificTimeZone);
+        }
+
+        [Benchmark]
         public void NextUnreachableSimple()
         {
             var result = SimpleUnreachableExpression.GetNextOccurrence(DateTimeNow, UtcTimeZone);
+            if (result != null) throw new InvalidOperationException();
+        }
+
+        [Benchmark]
+        public void PreviousUnreachableSimple()
+        {
+            var result = SimpleUnreachableExpression.GetPreviousOccurrence(DateTimeNow, UtcTimeZone);
             if (result != null) throw new InvalidOperationException();
         }
 
@@ -188,6 +231,13 @@ namespace Cronos.Benchmarks
         }
 
         [Benchmark]
+        public void PreviousUnreachableComplex()
+        {
+            var result = ComplexUnreachableExpression.GetPreviousOccurrence(DateTimeNow, UtcTimeZone);
+            if (result != null) throw new InvalidOperationException();
+        }
+
+        [Benchmark]
         public void NextUnreachableLastDayOfWeek()
         {
             var result = LastDayOfWeekUnreachableExpression.GetNextOccurrence(DateTimeNow, UtcTimeZone);
@@ -195,9 +245,23 @@ namespace Cronos.Benchmarks
         }
 
         [Benchmark]
+        public void PreviousUnreachableLastDayOfWeek()
+        {
+            var result = LastDayOfWeekUnreachableExpression.GetPreviousOccurrence(DateTimeNow, UtcTimeZone);
+            if (result != null) throw new InvalidOperationException();
+        }
+
+        [Benchmark]
         public void NextUnreachableNthDayOfWeek()
         {
             var result = NthDayOfWeekUnreachableExpression.GetNextOccurrence(DateTimeNow, UtcTimeZone);
+            if (result != null) throw new InvalidOperationException();
+        }
+
+        [Benchmark]
+        public void PreviousUnreachableNthDayOfWeek()
+        {
+            var result = NthDayOfWeekUnreachableExpression.GetPreviousOccurrence(DateTimeNow, UtcTimeZone);
             if (result != null) throw new InvalidOperationException();
         }
 
@@ -211,9 +275,25 @@ namespace Cronos.Benchmarks
         }
 
         [Benchmark]
+        public DateTimeOffset? PreviousHandlesInvalidTime()
+        {
+            var result = SimpleExpression.GetPreviousOccurrence(SecondBeforeInvalidTime, PacificTimeZone);
+            if (result.Value.Hour != 1 || result.Value.Minute != 59 || result.Value.Offset != PacificTimeZone.BaseUtcOffset)
+                throw new InvalidOperationException();
+
+            return result;
+        }
+
+        [Benchmark]
         public DateTimeOffset? NextHandlesAmbiguousDaylight()
         {
             return AmbiguousExpression.GetNextOccurrence(AmbiguousDaylightTime, PacificTimeZone);
+        }
+
+        [Benchmark]
+        public DateTimeOffset? PreviousHandlesAmbiguousDaylight()
+        {
+            return AmbiguousExpression.GetPreviousOccurrence(AmbiguousDaylightTime, PacificTimeZone);
         }
 
         [Benchmark]

--- a/src/Cronos/CronExpression.cs
+++ b/src/Cronos/CronExpression.cs
@@ -774,7 +774,14 @@ namespace Cronos
 
             if (zone.IsInvalidTime(occurrence))
             {
-                return TimeZoneHelper.GetStandardTimeEnd(zone, occurrence);
+                var previousValidTime = TimeZoneHelper.GetStandardTimeEnd(zone, occurrence);
+                if (previousValidTime.Date < occurrence.Date)
+                {
+                    var daylightTimeStart = TimeZoneHelper.GetDaylightTimeStart(zone, occurrence);
+                    return new DateTimeOffset(occurrence, daylightTimeStart.Offset);
+                }
+
+                return previousValidTime;
             }
 
             if (TimeZoneHelper.IsAmbiguousTime(zone, occurrence))

--- a/src/Cronos/CronExpression.cs
+++ b/src/Cronos/CronExpression.cs
@@ -319,6 +319,20 @@ namespace Cronos
         }
 
         /// <summary>
+        /// Calculates previous occurrence starting with <paramref name="fromUtc"/> (optionally <paramref name="inclusive"/>) in UTC time zone.
+        /// </summary>
+        /// <exception cref="ArgumentException"/>
+        public DateTime? GetPreviousOccurrence(DateTime fromUtc, bool inclusive = false)
+        {
+            if (fromUtc.Kind != DateTimeKind.Utc) ThrowWrongDateTimeKindException(nameof(fromUtc));
+
+            var found = FindPreviousOccurrence(fromUtc.Ticks, inclusive);
+            if (found == NotFound) return null;
+
+            return new DateTime(found, DateTimeKind.Utc);
+        }
+
+        /// <summary>
         /// Calculates next occurrence starting with <paramref name="fromUtc"/> (optionally <paramref name="inclusive"/>) in given <paramref name="zone"/>
         /// </summary>
         /// <exception cref="ArgumentException"/>
@@ -345,6 +359,32 @@ namespace Cronos
         }
 
         /// <summary>
+        /// Calculates previous occurrence starting with <paramref name="fromUtc"/> (optionally <paramref name="inclusive"/>) in given <paramref name="zone"/>
+        /// </summary>
+        /// <exception cref="ArgumentException"/>
+        public DateTime? GetPreviousOccurrence(DateTime fromUtc, TimeZoneInfo zone, bool inclusive = false)
+        {
+            if (fromUtc.Kind != DateTimeKind.Utc) ThrowWrongDateTimeKindException(nameof(fromUtc));
+            if (ReferenceEquals(zone, null)) ThrowArgumentNullException(nameof(zone));
+
+            if (ReferenceEquals(zone, UtcTimeZone))
+            {
+                var found = FindPreviousOccurrence(fromUtc.Ticks, inclusive);
+                if (found == NotFound) return null;
+
+                return new DateTime(found, DateTimeKind.Utc);
+            }
+
+            var fromOffset = new DateTimeOffset(fromUtc);
+
+#pragma warning disable CA1062
+            var occurrence = GetPreviousOccurrenceConsideringTimeZone(fromOffset, zone, inclusive);
+#pragma warning restore CA1062
+
+            return occurrence?.UtcDateTime;
+        }
+
+        /// <summary>
         /// Calculates next occurrence starting with <paramref name="from"/> (optionally <paramref name="inclusive"/>) in given <paramref name="zone"/>
         /// </summary>
         /// <exception cref="ArgumentException"/>
@@ -362,6 +402,27 @@ namespace Cronos
 
 #pragma warning disable CA1062
             return GetOccurrenceConsideringTimeZone(from, zone, inclusive);
+#pragma warning restore CA1062
+        }
+
+        /// <summary>
+        /// Calculates previous occurrence starting with <paramref name="from"/> (optionally <paramref name="inclusive"/>) in given <paramref name="zone"/>
+        /// </summary>
+        /// <exception cref="ArgumentException"/>
+        public DateTimeOffset? GetPreviousOccurrence(DateTimeOffset from, TimeZoneInfo zone, bool inclusive = false)
+        {
+            if (ReferenceEquals(zone, null)) ThrowArgumentNullException(nameof(zone));
+
+            if (ReferenceEquals(zone, UtcTimeZone))
+            {
+                var found = FindPreviousOccurrence(from.UtcTicks, inclusive);
+                if (found == NotFound) return null;
+
+                return new DateTimeOffset(found, TimeSpan.Zero);
+            }
+
+#pragma warning disable CA1062
+            return GetPreviousOccurrenceConsideringTimeZone(from, zone, inclusive);
 #pragma warning restore CA1062
         }
 
@@ -435,6 +496,75 @@ namespace Cronos
                 // ReSharper disable once RedundantArgumentDefaultValue
                 // ReSharper disable once ArgumentsStyleLiteral
                 occurrence = GetNextOccurrence(occurrence.Value, zone, inclusive: false))
+            {
+                yield return occurrence.Value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the list of previous occurrences within the given date/time range,
+        /// including <paramref name="fromUtc"/> and excluding <paramref name="toUtc"/>
+        /// by default, and UTC time zone. When none of the occurrences found, an
+        /// empty list is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException"/>
+        public IEnumerable<DateTime> GetOccurrencesDescending(
+            DateTime fromUtc,
+            DateTime toUtc,
+            bool fromInclusive = true,
+            bool toInclusive = false)
+        {
+            if (fromUtc < toUtc) ThrowFromShouldBeGreaterThanToException(nameof(fromUtc), nameof(toUtc));
+
+            for (var occurrence = GetPreviousOccurrence(fromUtc, fromInclusive);
+                occurrence > toUtc || occurrence == toUtc && toInclusive;
+                occurrence = GetPreviousOccurrence(occurrence.Value, inclusive: false))
+            {
+                yield return occurrence.Value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the list of previous occurrences within the given date/time range, including
+        /// <paramref name="fromUtc"/> and excluding <paramref name="toUtc"/> by default, and
+        /// specified time zone. When none of the occurrences found, an empty list is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException"/>
+        public IEnumerable<DateTime> GetOccurrencesDescending(
+            DateTime fromUtc,
+            DateTime toUtc,
+            TimeZoneInfo zone,
+            bool fromInclusive = true,
+            bool toInclusive = false)
+        {
+            if (fromUtc < toUtc) ThrowFromShouldBeGreaterThanToException(nameof(fromUtc), nameof(toUtc));
+
+            for (var occurrence = GetPreviousOccurrence(fromUtc, zone, fromInclusive);
+                occurrence > toUtc || occurrence == toUtc && toInclusive;
+                occurrence = GetPreviousOccurrence(occurrence.Value, zone, inclusive: false))
+            {
+                yield return occurrence.Value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the list of previous occurrences within the given date/time offset range,
+        /// including <paramref name="from"/> and excluding <paramref name="to"/> by default.
+        /// When none of the occurrences found, an empty list is returned.
+        /// </summary>
+        /// <exception cref="ArgumentException"/>
+        public IEnumerable<DateTimeOffset> GetOccurrencesDescending(
+            DateTimeOffset from,
+            DateTimeOffset to,
+            TimeZoneInfo zone,
+            bool fromInclusive = true,
+            bool toInclusive = false)
+        {
+            if (from < to) ThrowFromShouldBeGreaterThanToException(nameof(from), nameof(to));
+
+            for (var occurrence = GetPreviousOccurrence(from, zone, fromInclusive);
+                occurrence > to || occurrence == to && toInclusive;
+                occurrence = GetPreviousOccurrence(occurrence.Value, zone, inclusive: false))
             {
                 yield return occurrence.Value;
             }
@@ -595,11 +725,85 @@ namespace Cronos
             return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
         }
 
+        private DateTimeOffset? GetPreviousOccurrenceConsideringTimeZone(DateTimeOffset fromUtc, TimeZoneInfo zone, bool inclusive)
+        {
+            if (!DateTimeHelper.IsRound(fromUtc))
+            {
+                fromUtc = DateTimeHelper.FloorToSeconds(fromUtc);
+            }
+
+            var from = TimeZoneInfo.ConvertTime(fromUtc, zone);
+            var fromLocal = from.DateTime;
+
+            if (TimeZoneHelper.IsAmbiguousTime(zone, fromLocal))
+            {
+                var currentOffset = from.Offset;
+                var standardOffset = zone.GetUtcOffset(fromLocal);
+                var daylightOffset = TimeZoneHelper.GetDaylightOffset(zone, fromLocal);
+                var ambiguousIntervalStart = TimeZoneHelper.GetStandardTimeStart(zone, fromLocal, daylightOffset).DateTime;
+
+                if (standardOffset == currentOffset)
+                {
+                    if (HasFlag(CronExpressionFlag.Interval))
+                    {
+                        var foundInStandardOffset = FindPreviousOccurrence(fromLocal.Ticks, ambiguousIntervalStart.Ticks, inclusive);
+                        if (foundInStandardOffset != NotFound) return new DateTimeOffset(foundInStandardOffset, standardOffset);
+                    }
+
+                    var daylightTimeLocalEnd = TimeZoneHelper.GetDaylightTimeEnd(zone, fromLocal, daylightOffset).DateTime;
+                    var foundInDaylightOffset = FindPreviousOccurrence(daylightTimeLocalEnd.Ticks, ambiguousIntervalStart.Ticks, true);
+                    if (foundInDaylightOffset != NotFound) return new DateTimeOffset(foundInDaylightOffset, daylightOffset);
+
+                    fromLocal = ambiguousIntervalStart.AddTicks(-1);
+                    inclusive = true;
+                }
+                else
+                {
+                    var foundInDaylightOffset = FindPreviousOccurrence(fromLocal.Ticks, ambiguousIntervalStart.Ticks, inclusive);
+                    if (foundInDaylightOffset != NotFound) return new DateTimeOffset(foundInDaylightOffset, daylightOffset);
+
+                    fromLocal = ambiguousIntervalStart.AddTicks(-1);
+                    inclusive = true;
+                }
+            }
+
+            var occurrenceTicks = FindPreviousOccurrence(fromLocal.Ticks, inclusive);
+            if (occurrenceTicks == NotFound) return null;
+
+            var occurrence = new DateTime(occurrenceTicks, DateTimeKind.Unspecified);
+
+            if (zone.IsInvalidTime(occurrence))
+            {
+                return TimeZoneHelper.GetStandardTimeEnd(zone, occurrence);
+            }
+
+            if (TimeZoneHelper.IsAmbiguousTime(zone, occurrence))
+            {
+                var daylightOffset = TimeZoneHelper.GetDaylightOffset(zone, occurrence);
+                if (HasFlag(CronExpressionFlag.Interval))
+                {
+                    return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
+                }
+
+                return new DateTimeOffset(occurrence, daylightOffset);
+            }
+
+            return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
+        }
+
         private long FindOccurrence(long startTimeTicks, long endTimeTicks, bool startInclusive)
         {
             var found = FindOccurrence(startTimeTicks, startInclusive);
 
             if (found == NotFound || found > endTimeTicks) return NotFound;
+            return found;
+        }
+
+        private long FindPreviousOccurrence(long startTimeTicks, long endTimeTicks, bool startInclusive)
+        {
+            var found = FindPreviousOccurrence(startTimeTicks, startInclusive);
+
+            if (found == NotFound || found < endTimeTicks) return NotFound;
             return found;
         }
 
@@ -681,6 +885,79 @@ namespace Cronos
             goto Retry;
         }
 
+        private long FindPreviousOccurrence(long ticks, bool startInclusive)
+        {
+            if (!startInclusive)
+            {
+                if (ticks == DateTime.MinValue.Ticks) return NotFound;
+                ticks--;
+            }
+
+            CalendarHelper.FillDateTimeParts(
+                ticks,
+                out int startSecond,
+                out int startMinute,
+                out int startHour,
+                out int startDay,
+                out int startMonth,
+                out int startYear);
+
+            if (ticks % TimeSpan.TicksPerSecond != 0) startSecond--;
+
+            var maxMatchedDay = HasFlag(CronExpressionFlag.DayOfMonthLast) || HasFlag(CronExpressionFlag.NearestWeekday)
+                ? CronField.DaysOfMonth.Last
+                : GetLastSet(_dayOfMonth);
+
+            var second = startSecond;
+            var minute = startMinute;
+            var hour = startHour;
+            var day = startDay;
+            var month = startMonth;
+            var year = startYear;
+
+            if (!GetBit(_second, second) && !MoveBack(_second, ref second)) minute--;
+            if (minute < CronField.Minutes.First || !GetBit(_minute, minute) && !MoveBack(_minute, ref minute)) hour--;
+            if (hour < CronField.Hours.First || !GetBit(_hour, hour) && !MoveBack(_hour, ref hour)) day--;
+
+            if (!GetBit(_month, month)) goto RetryMonth;
+
+            Retry:
+
+            if (!TryGetPreviousDay(year, month, day, out var lastCheckedDay, out var actualDay)) goto RetryMonth;
+
+            if (CalendarHelper.IsGreaterThan(startYear, startMonth, startDay, year, month, actualDay)) goto RolloverDay;
+            if (hour < startHour) goto RolloverHour;
+            if (minute < startMinute) goto RolloverMinute;
+            goto ReturnResult;
+
+            RolloverDay: hour = GetLastSet(_hour);
+            RolloverHour: minute = GetLastSet(_minute);
+            RolloverMinute: second = GetLastSet(_second);
+
+            ReturnResult:
+
+            var found = CalendarHelper.DateTimeToTicks(year, month, actualDay, hour, minute, second);
+            if (found <= ticks) return found;
+
+            day = lastCheckedDay;
+            if (MoveBackDay(ref day)) goto Retry;
+
+            RetryMonth:
+
+            if (!MoveBack(_month, ref month))
+            {
+                year--;
+                if (year < DateTime.MinValue.Year)
+                {
+                    return NotFound;
+                }
+            }
+
+            day = maxMatchedDay;
+
+            goto Retry;
+        }
+
         private static bool Move(ulong fieldBits, ref int fieldValue)
         {
             if (fieldBits >> ++fieldValue == 0)
@@ -691,6 +968,164 @@ namespace Cronos
 
             fieldValue += GetFirstSet(fieldBits >> fieldValue);
             return true;
+        }
+
+        private static bool MoveBack(ulong fieldBits, ref int fieldValue)
+        {
+            var eligibleBits = GetBitsAtOrBelow(fieldBits, fieldValue - 1);
+            if (eligibleBits == 0)
+            {
+                fieldValue = GetLastSet(fieldBits);
+                return false;
+            }
+
+            fieldValue = GetLastSet(eligibleBits);
+            return true;
+        }
+
+        private bool TryGetPreviousDay(int year, int month, int dayLimit, out int day, out int actualDay)
+        {
+            var lastDayOfMonth = CalendarHelper.GetDaysInMonth(year, month);
+            var maxDay = dayLimit > lastDayOfMonth ? lastDayOfMonth : dayLimit;
+
+            if (HasFlag(CronExpressionFlag.NearestWeekday))
+            {
+                day = HasFlag(CronExpressionFlag.DayOfMonthLast)
+                    ? GetLastDayOfMonth(year, month)
+                    : GetFirstSet(_dayOfMonth);
+
+                actualDay = CalendarHelper.MoveToNearestWeekDay(year, month, day);
+                return actualDay <= maxDay && IsDayOfWeekMatch(year, month, actualDay);
+            }
+
+            if (HasFlag(CronExpressionFlag.DayOfMonthLast))
+            {
+                day = GetLastDayOfMonth(year, month);
+                actualDay = day;
+                return actualDay <= maxDay && IsDayOfWeekMatch(year, month, actualDay);
+            }
+
+            if (_dayOfMonth == CronField.DaysOfMonth.AllBits &&
+                !HasFlag(CronExpressionFlag.DayOfWeekLast) &&
+                !HasFlag(CronExpressionFlag.NthDayOfWeek))
+            {
+                day = maxDay;
+                actualDay = day;
+
+                if (_dayOfWeek == CronField.DaysOfWeek.AllBits)
+                {
+                    return true;
+                }
+
+                var dayOfWeek = (int)CalendarHelper.GetDayOfWeek(year, month, day);
+
+                for (var delta = 0; delta < 7 && day - delta >= CronField.DaysOfMonth.First; delta++)
+                {
+                    var candidateDayOfWeek = dayOfWeek - delta;
+                    if (candidateDayOfWeek < 0) candidateDayOfWeek += 7;
+
+                    if (((_dayOfWeek >> candidateDayOfWeek) & 1) == 0) continue;
+
+                    day -= delta;
+                    actualDay = day;
+                    return true;
+                }
+
+                actualDay = default;
+                return false;
+            }
+
+            day = maxDay;
+
+            if (!GetBit(_dayOfMonth, day) && !MoveBackDay(ref day))
+            {
+                actualDay = default;
+                return false;
+            }
+
+            Retry:
+
+            if (day > lastDayOfMonth)
+            {
+                if (MoveBackDay(ref day)) goto Retry;
+
+                actualDay = default;
+                return false;
+            }
+
+            actualDay = day;
+            if (IsDayOfWeekMatch(year, month, actualDay))
+            {
+                return true;
+            }
+
+            if (MoveBackDay(ref day))
+            {
+                goto Retry;
+            }
+
+            actualDay = default;
+            return false;
+        }
+
+        private bool MoveBackDay(ref int day)
+        {
+            if (HasFlag(CronExpressionFlag.NearestWeekday) || HasFlag(CronExpressionFlag.DayOfMonthLast))
+            {
+                return false;
+            }
+
+            if (_dayOfMonth == CronField.DaysOfMonth.AllBits)
+            {
+                if (day <= CronField.DaysOfMonth.First)
+                {
+                    day = CronField.DaysOfMonth.Last;
+                    return false;
+                }
+
+                day--;
+                return true;
+            }
+
+            return MoveBack(_dayOfMonth, ref day);
+        }
+
+        private bool IsDayMatch(int year, int month, int day)
+        {
+            bool dayOfMonthMatch;
+
+            if (HasFlag(CronExpressionFlag.NearestWeekday))
+            {
+                dayOfMonthMatch = false;
+                var lastDay = CalendarHelper.GetDaysInMonth(year, month);
+
+                if (HasFlag(CronExpressionFlag.DayOfMonthLast))
+                {
+                    var targetDay = GetLastDayOfMonth(year, month);
+                    dayOfMonthMatch = CalendarHelper.MoveToNearestWeekDay(year, month, targetDay) == day;
+                }
+                else
+                {
+                    for (var targetDay = CronField.DaysOfMonth.First; targetDay <= lastDay; targetDay++)
+                    {
+                        if (!GetBit(_dayOfMonth, targetDay)) continue;
+                        if (CalendarHelper.MoveToNearestWeekDay(year, month, targetDay) != day) continue;
+
+                        dayOfMonthMatch = true;
+                        break;
+                    }
+                }
+            }
+            else if (HasFlag(CronExpressionFlag.DayOfMonthLast))
+            {
+                dayOfMonthMatch = GetLastDayOfMonth(year, month) == day;
+            }
+            else
+            {
+                dayOfMonthMatch = GetBit(_dayOfMonth, day);
+            }
+
+            return dayOfMonthMatch && IsDayOfWeekMatch(year, month, day);
         }
 
         private int GetLastDayOfMonth(int year, int month)
@@ -718,6 +1153,31 @@ namespace Cronos
             // TODO: Add description and source
             ulong res = unchecked((ulong)((long)value & -(long)value) * 0x022fdd63cc95386d) >> 58;
             return DeBruijnPositions[res];
+        }
+
+        private static int GetLastSet(ulong value)
+        {
+            var index = 0;
+
+            while ((value >>= 1) != 0)
+            {
+                index++;
+            }
+
+            return index;
+        }
+
+        private static int GetLastSetWithin(ulong fieldBits, int maxValue)
+        {
+            return GetLastSet(GetBitsAtOrBelow(fieldBits, maxValue));
+        }
+
+        private static ulong GetBitsAtOrBelow(ulong fieldBits, int maxValue)
+        {
+            if (maxValue < 0) return 0;
+            if (maxValue >= 63) return fieldBits;
+
+            return fieldBits & ((1UL << (maxValue + 1)) - 1);
         }
 
         private bool HasFlag(CronExpressionFlag value)
@@ -772,6 +1232,13 @@ namespace Cronos
         private static void ThrowFromShouldBeLessThanToException(string fromName, string toName)
         {
             throw new ArgumentException($"The value of the {fromName} argument should be less than the value of the {toName} argument.", fromName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [DoesNotReturn]
+        private static void ThrowFromShouldBeGreaterThanToException(string fromName, string toName)
+        {
+            throw new ArgumentException($"The value of the {fromName} argument should be greater than or equal to the value of the {toName} argument.", fromName);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Cronos/TimeZoneHelper.cs
+++ b/src/Cronos/TimeZoneHelper.cs
@@ -62,6 +62,22 @@ namespace Cronos
             return new DateTimeOffset(dstTransitionDateTime, dstOffset);
         }
 
+        public static DateTimeOffset GetStandardTimeEnd(TimeZoneInfo zone, DateTime invalidDateTime)
+        {
+            var dstTransitionDateTime = new DateTime(invalidDateTime.Year, invalidDateTime.Month, invalidDateTime.Day,
+                invalidDateTime.Hour, invalidDateTime.Minute, 0, 0, invalidDateTime.Kind);
+
+            while (zone.IsInvalidTime(dstTransitionDateTime))
+            {
+                dstTransitionDateTime = dstTransitionDateTime.AddMinutes(-1);
+            }
+
+            var standardOffset = zone.GetUtcOffset(dstTransitionDateTime);
+            var lastValidSecond = dstTransitionDateTime.AddMinutes(1).AddSeconds(-1);
+
+            return new DateTimeOffset(lastValidSecond, standardOffset);
+        }
+
         public static DateTimeOffset GetStandardTimeStart(TimeZoneInfo zone, DateTime ambiguousTime, TimeSpan daylightOffset)
         {
             var dstTransitionEnd = GetDstTransitionEndDateTime(zone, ambiguousTime);

--- a/tests/Cronos.Tests/CronExpressionReverseFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionReverseFacts.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Xunit;
+
+namespace Cronos.Tests
+{
+    public class CronExpressionReverseFacts
+    {
+        private static readonly bool IsUnix =
+#if NETCOREAPP1_1
+            !System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+#else
+            Environment.OSVersion.Platform == PlatformID.MacOSX || Environment.OSVersion.Platform == PlatformID.Unix;
+#endif
+
+        private static readonly string EasternTimeZoneId = IsUnix ? "America/New_York" : "Eastern Standard Time";
+        private static readonly string JordanTimeZoneId = IsUnix ? "Asia/Amman" : "Jordan Standard Time";
+        private static readonly string LordHoweTimeZoneId = IsUnix ? "Australia/Lord_Howe" : "Lord Howe Standard Time";
+        private static readonly string PacificTimeZoneId = IsUnix ? "America/Santiago" : "Pacific SA Standard Time";
+
+        private static readonly TimeZoneInfo EasternTimeZone = TimeZoneInfo.FindSystemTimeZoneById(EasternTimeZoneId);
+        private static readonly TimeZoneInfo JordanTimeZone = TimeZoneInfo.FindSystemTimeZoneById(JordanTimeZoneId);
+        private static readonly TimeZoneInfo LordHoweTimeZone = TimeZoneInfo.FindSystemTimeZoneById(LordHoweTimeZoneId);
+        private static readonly TimeZoneInfo PacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById(PacificTimeZoneId);
+
+        [Theory]
+        [InlineData(DateTimeKind.Unspecified, false)]
+        [InlineData(DateTimeKind.Unspecified, true)]
+        [InlineData(DateTimeKind.Local, false)]
+        [InlineData(DateTimeKind.Local, true)]
+        public void GetPreviousOccurrence_ThrowsAnException_WhenFromDoesNotHaveUtcKind(DateTimeKind kind, bool inclusive)
+        {
+            var from = new DateTime(2017, 03, 15, 0, 0, 0, kind);
+
+            var exception = Assert.Throws<ArgumentException>(() => CronExpression.EveryMinute.GetPreviousOccurrence(from, inclusive));
+
+            Assert.Equal("fromUtc", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(DateTimeKind.Unspecified, false)]
+        [InlineData(DateTimeKind.Unspecified, true)]
+        [InlineData(DateTimeKind.Local, false)]
+        [InlineData(DateTimeKind.Local, true)]
+        public void GetPreviousOccurrence_DateTimeTimeZone_ThrowsAnException_WhenFromHasAWrongKind(DateTimeKind kind, bool inclusive)
+        {
+            var from = new DateTime(2017, 03, 22, 0, 0, 0, kind);
+
+            var exception = Assert.Throws<ArgumentException>(() => CronExpression.EveryMinute.GetPreviousOccurrence(from, TimeZoneInfo.Local, inclusive));
+
+            Assert.Equal("fromUtc", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_DateTimeTimeZone_ThrowsAnException_WhenZoneIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => CronExpression.EveryMinute.GetPreviousOccurrence(DateTime.UtcNow, null!));
+
+            Assert.Equal("zone", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_DateTimeOffsetTimeZone_ThrowsAnException_WhenZoneIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => CronExpression.EveryMinute.GetPreviousOccurrence(DateTimeOffset.UtcNow, null!));
+
+            Assert.Equal("zone", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(false, "2017-03-22 09:31:00")]
+        [InlineData(true, "2017-03-22 09:32:00")]
+        public void GetPreviousOccurrence_ReturnsCorrectUtcDate(bool inclusive, string expectedString)
+        {
+            var from = new DateTime(2017, 03, 22, 9, 32, 0, DateTimeKind.Utc);
+            var expected = GetUtcDateTime(expectedString);
+
+            var occurrence = CronExpression.EveryMinute.GetPreviousOccurrence(from, inclusive);
+
+            Assert.Equal(expected, occurrence);
+            Assert.Equal(DateTimeKind.Utc, occurrence?.Kind);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_WhenSecondsAreIncluded()
+        {
+            var expression = CronExpression.Parse("20 * * * * *", CronFormat.IncludeSeconds);
+            var from = GetUtcDateTime("2017-03-22 17:35:40");
+
+            var previous = expression.GetPreviousOccurrence(from);
+
+            Assert.Equal(GetUtcDateTime("2017-03-22 17:35:20"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_ForComplexUtcExpression()
+        {
+            var expression = CronExpression.Parse("*/10 12-20 * DEC 3");
+            var from = GetUtcDateTime("2017-12-06 12:00:00");
+
+            var previous = expression.GetPreviousOccurrence(from, inclusive: true);
+
+            Assert.Equal(GetUtcDateTime("2017-12-06 12:00:00"), previous);
+        }
+
+        [Theory]
+        [InlineData("10-30 * * * * *", "2017-03-22 17:35:31", "2017-03-22 17:35:30", CronFormat.IncludeSeconds)]
+        [InlineData("0 0 20-5/5 * *", "2017-06-05 00:00:00", "2017-06-04 00:00:00", CronFormat.Standard)]
+        [InlineData("0 0 * 12-2 *", "2017-03-01 00:00:00", "2017-02-28 00:00:00", CronFormat.Standard)]
+        [InlineData("0 0 * * thu-sat", "2016-12-12 00:00:00", "2016-12-10 00:00:00", CronFormat.Standard)]
+        [InlineData("0 5 18 13 * 5", "2017-10-13 18:05:00", "2017-01-13 18:05:00", CronFormat.IncludeSeconds)]
+        [InlineData("0 0 L-1 * *", "2016-12-30 00:00:00", "2016-11-29 00:00:00", CronFormat.Standard)]
+        [InlineData("0 0 L-2W * *", "2017-03-01 00:00:00", "2017-02-27 00:00:00", CronFormat.Standard)]
+        [InlineData("0 0 * * SUN#1", "2017-02-05 00:00:00", "2017-01-01 00:00:00", CronFormat.Standard)]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_ForBroaderUtcMatrix(string cronExpression, string fromString, string expectedString, CronFormat format)
+        {
+            var expression = CronExpression.Parse(cronExpression, format);
+            var from = GetUtcDateTime(fromString);
+
+            var previous = expression.GetPreviousOccurrence(from);
+
+            Assert.Equal(GetUtcDateTime(expectedString), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_WhenMacroExpressionHasJitterSeed()
+        {
+            var expression = CronExpression.Parse("@daily", 12345);
+            var from = GetLocalInstant("2017-03-22 12:00:00", EasternTimeZone);
+            var startOfDay = GetLocalInstant("2017-03-22 00:00:00", EasternTimeZone);
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+            var next = expression.GetNextOccurrence(previous!.Value, EasternTimeZone);
+            var nextFromStartOfDay = expression.GetNextOccurrence(startOfDay, EasternTimeZone, inclusive: true);
+
+            Assert.True(previous < from);
+            Assert.Equal(nextFromStartOfDay, next);
+            Assert.True(next > from);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_ReturnsNull_WhenCronExpressionIsUnreachable()
+        {
+            var expression = CronExpression.Parse("* * 31 2 *");
+            var from = GetUtcDateTime("2017-03-22 00:00:00");
+
+            var previous = expression.GetPreviousOccurrence(from);
+
+            Assert.Null(previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_RollsBackAcrossMonthBoundary()
+        {
+            var expression = CronExpression.Parse("0 0 1 * *");
+            var from = GetUtcDateTime("2017-03-01 00:00:00");
+
+            var previous = expression.GetPreviousOccurrence(from);
+
+            Assert.Equal(GetUtcDateTime("2017-02-01 00:00:00"), previous);
+        }
+
+        [Theory]
+        [InlineData("0 0 L * *", "2017-03-31 00:00:00", "2017-02-28 00:00:00")]
+        [InlineData("0 0 1W * *", "2017-03-03 00:00:00", "2017-03-01 00:00:00")]
+        [InlineData("0 0 LW * *", "2017-04-01 00:00:00", "2017-03-31 00:00:00")]
+        [InlineData("0 0 * * 6#3", "2017-03-19 00:00:00", "2017-03-18 00:00:00")]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_ForSpecialDayModifiers(string cronExpression, string fromString, string expectedString)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+            var from = GetUtcDateTime(fromString);
+
+            var previous = expression.GetPreviousOccurrence(from);
+
+            Assert.Equal(GetUtcDateTime(expectedString), previous);
+        }
+
+        [Theory]
+        [InlineData("0 0 L-1W * *", "2017-03-01 00:00:00", "2017-02-27 00:00:00")]
+        [InlineData("0 0 ? * sat-tue", "2016-12-14 00:00:00", "2016-12-13 00:00:00")]
+        [InlineData("0 0 13 * 5", "2017-10-13 00:00:00", "2017-01-13 00:00:00")]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_ForAdditionalReverseCases(string cronExpression, string fromString, string expectedString)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+            var from = GetUtcDateTime(fromString);
+
+            var previous = expression.GetPreviousOccurrence(from);
+
+            Assert.Equal(GetUtcDateTime(expectedString), previous);
+        }
+
+        [Fact]
+        public void GetOccurrencesDescending_ReturnsExpectedCollection()
+        {
+            var expression = CronExpression.Parse("* * * * *");
+            var from = GetUtcDateTime("2017-03-22 00:02:00");
+            var to = GetUtcDateTime("2017-03-22 00:00:00");
+
+            var occurrences = expression
+                .GetOccurrencesDescending(from, to, fromInclusive: true, toInclusive: true)
+                .ToArray();
+
+            Assert.Equal(
+                new[]
+                {
+                    GetUtcDateTime("2017-03-22 00:02:00"),
+                    GetUtcDateTime("2017-03-22 00:01:00"),
+                    GetUtcDateTime("2017-03-22 00:00:00")
+                },
+                occurrences);
+        }
+
+        [Fact]
+        public void GetOccurrencesDescending_ReturnsReverseOfForwardCollection()
+        {
+            var expression = CronExpression.Parse("*/15 * * * *");
+            var from = GetUtcDateTime("2017-03-22 01:00:00");
+            var to = GetUtcDateTime("2017-03-22 00:00:00");
+
+            var descending = expression.GetOccurrencesDescending(from, to, fromInclusive: true, toInclusive: true).ToArray();
+            var ascending = expression.GetOccurrences(to, from, fromInclusive: true, toInclusive: true).Reverse().ToArray();
+
+            Assert.Equal(ascending, descending);
+        }
+
+        [Fact]
+        public void GetOccurrencesDescending_ReturnsReverseOfForwardCollection_WhenZoneIsSpecified()
+        {
+            var expression = CronExpression.Parse("0 */30 * * * *", CronFormat.IncludeSeconds);
+            var from = GetUtcDateTime("2016-11-06 07:00:00");
+            var to = GetUtcDateTime("2016-11-06 04:00:00");
+
+            var descending = expression.GetOccurrencesDescending(from, to, EasternTimeZone, fromInclusive: true, toInclusive: true).ToArray();
+            var ascending = expression.GetOccurrences(to, from, EasternTimeZone, fromInclusive: true, toInclusive: true).Reverse().ToArray();
+
+            Assert.Equal(ascending, descending);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_CanStepAcrossJordanDstAdjustedMonthlySequence()
+        {
+            var expression = CronExpression.Parse("30 0 L * *");
+            var from = GetInstant("2017-04-30 00:30:00 +03:00");
+
+            var previous = expression.GetPreviousOccurrence(from, JordanTimeZone, inclusive: false);
+            var beforePrevious = expression.GetPreviousOccurrence(previous!.Value, JordanTimeZone, inclusive: false);
+
+            Assert.Equal(GetInstant("2017-03-31 00:30:00 +03:00"), previous);
+            Assert.Equal(GetInstant("2017-02-28 00:30:00 +02:00"), beforePrevious);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_CanStepAcrossLordHoweRepeatedHourIntervalSequence()
+        {
+            var expression = CronExpression.Parse("0 */30 1 * * *", CronFormat.IncludeSeconds);
+            var from = GetInstant("2017-04-02 01:30:00 +10:30");
+
+            var previous = expression.GetPreviousOccurrence(from, LordHoweTimeZone, inclusive: false);
+            var beforePrevious = expression.GetPreviousOccurrence(previous!.Value, LordHoweTimeZone, inclusive: false);
+
+            Assert.Equal(GetInstant("2017-04-02 01:30:00 +11:00"), previous);
+            Assert.Equal(GetInstant("2017-04-02 01:00:00 +11:00"), beforePrevious);
+        }
+
+        [Fact]
+        public void GetOccurrencesDescending_DateTime_ThrowsAnException_WhenFromLessThanTo()
+        {
+            var expression = CronExpression.Parse("* * * * *");
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => expression.GetOccurrencesDescending(DateTime.UtcNow, DateTime.UtcNow.AddMinutes(1)).ToArray());
+
+            Assert.Equal("fromUtc", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_UsesSingleOccurrenceForAmbiguousNonIntervalTime()
+        {
+            var expression = CronExpression.Parse("30 1 * * *");
+            var from = GetInstant("2017-11-05 03:00:00 -05:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-11-05 01:30:00 -04:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_PreservesAmbiguousIntervalOccurrencesInReverseOrder()
+        {
+            var expression = CronExpression.Parse("*/30 1 5 11 *");
+            var from = GetInstant("2017-11-05 02:00:00 -05:00");
+
+            var first = expression.GetPreviousOccurrence(from, EasternTimeZone);
+            var second = expression.GetPreviousOccurrence(first!.Value, EasternTimeZone);
+            var third = expression.GetPreviousOccurrence(second!.Value, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-11-05 01:30:00 -05:00"), first);
+            Assert.Equal(GetInstant("2017-11-05 01:00:00 -05:00"), second);
+            Assert.Equal(GetInstant("2017-11-05 01:30:00 -04:00"), third);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_AdjustsInvalidTimeBackwardAcrossSpringForward()
+        {
+            var expression = CronExpression.Parse("30 2 * * *");
+            var from = GetInstant("2017-03-12 04:00:00 -04:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-03-12 01:59:59 -05:00"), previous);
+        }
+
+        [Theory]
+        [InlineData("30 0 L * *", "2017-04-30 00:30 +03:00", "2017-03-31 00:30 +03:00")]
+        [InlineData("30 0 LW * *", "2018-04-30 00:30 +03:00", "2018-03-30 00:30 +03:00")]
+        public void GetPreviousOccurrence_HandleJordanForwardShiftCases(string cronExpression, string fromString, string expectedString)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+            var from = GetInstant(fromString);
+
+            var previous = expression.GetPreviousOccurrence(from, JordanTimeZone);
+
+            Assert.Equal(GetInstant(expectedString), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_HandleLordHoweBackwardShift_ForNonIntervalExpression()
+        {
+            var expression = CronExpression.Parse("0 30 1 * * *", CronFormat.IncludeSeconds);
+            var from = GetInstant("2017-04-03 01:30:00 +10:30");
+
+            var previous = expression.GetPreviousOccurrence(from, LordHoweTimeZone);
+
+            Assert.Equal(GetInstant("2017-04-02 01:30:00 +11:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_HandlePacificBackwardShift_AroundRepeatedHour()
+        {
+            var expression = CronExpression.Parse("30 23 * * *");
+            var from = GetInstant("2017-05-14 23:30:00 -04:00");
+
+            var previous = expression.GetPreviousOccurrence(from, PacificTimeZone);
+
+            Assert.Equal(GetInstant("2017-05-13 23:30:00 -03:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_DoesNotReturnValueLaterThanNonRoundInput()
+        {
+            var expression = CronExpression.Parse("* * * * *");
+            var from = GetInstant("2017-03-12 03:00:00.5000000 -04:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone, inclusive: true);
+
+            Assert.True(previous <= from);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_FromDateTimeMinValueInclusive_SuccessfullyReturned()
+        {
+            var from = new DateTime(0, DateTimeKind.Utc);
+
+            var previous = CronExpression.Parse("* * * * *")
+                .GetPreviousOccurrence(from, inclusive: true);
+
+            Assert.Equal(from, previous);
+        }
+
+        private static DateTime GetUtcDateTime(string dateTimeString)
+        {
+            var dateTime = DateTime.ParseExact(
+                dateTimeString,
+                new[]
+                {
+                    "yyyy-MM-dd HH:mm:ss",
+                    "yyyy-MM-dd HH:mm"
+                },
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None);
+
+            return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+        }
+
+        private static DateTimeOffset GetLocalInstant(string localDateTimeString, TimeZoneInfo zone)
+        {
+            var dateTime = DateTime.ParseExact(
+                localDateTimeString,
+                new[]
+                {
+                    "yyyy-MM-dd HH:mm:ss",
+                    "yyyy-MM-dd HH:mm"
+                },
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None);
+
+            return new DateTimeOffset(dateTime, zone.GetUtcOffset(dateTime));
+        }
+
+        private static DateTimeOffset GetInstant(string dateTimeOffsetString)
+        {
+            return DateTimeOffset.ParseExact(
+                dateTimeOffsetString,
+                new[]
+                {
+                    "yyyy-MM-dd HH:mm zzz",
+                    "yyyy-MM-dd HH:mm:ss zzz",
+                    "yyyy-MM-dd HH:mm:ss.fffffff zzz"
+                },
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None);
+        }
+    }
+}

--- a/tests/Cronos.Tests/CronExpressionReverseFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionReverseFacts.cs
@@ -142,6 +142,21 @@ namespace Cronos.Tests
         }
 
         [Fact]
+        public void GetPreviousOccurrence_ReturnsCorrectDate_WhenExpressionContainsHash()
+        {
+            var expression = CronExpression.Parse("H * * * *", 3);
+            var from = GetLocalInstant("2017-03-23 17:18:00", EasternTimeZone);
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+            var next = expression.GetNextOccurrence(previous!.Value, EasternTimeZone);
+
+            Assert.Equal(GetLocalInstant("2017-03-23 17:17:00", EasternTimeZone), previous);
+            Assert.Equal(GetLocalInstant("2017-03-23 18:17:00", EasternTimeZone), next);
+            Assert.True(previous < from);
+            Assert.True(next > from);
+        }
+
+        [Fact]
         public void GetPreviousOccurrence_ReturnsNull_WhenCronExpressionIsUnreachable()
         {
             var expression = CronExpression.Parse("* * 31 2 *");

--- a/tests/Cronos.Tests/CronExpressionReverseFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionReverseFacts.cs
@@ -303,6 +303,17 @@ namespace Cronos.Tests
         }
 
         [Fact]
+        public void GetPreviousOccurrence_UsesSingleOccurrenceForAmbiguousNonIntervalHashTime()
+        {
+            var expression = CronExpression.Parse("0 H 1 * * *", CronFormat.IncludeSeconds, 3);
+            var from = GetInstant("2017-11-05 03:00:00 -05:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-11-05 01:17:00 -04:00"), previous);
+        }
+
+        [Fact]
         public void GetPreviousOccurrence_PreservesAmbiguousIntervalOccurrencesInReverseOrder()
         {
             var expression = CronExpression.Parse("*/30 1 5 11 *");
@@ -318,9 +329,35 @@ namespace Cronos.Tests
         }
 
         [Fact]
+        public void GetPreviousOccurrence_PreservesAmbiguousHashIntervalOccurrencesInReverseOrder()
+        {
+            var expression = CronExpression.Parse("0 H/30 1 * * *", CronFormat.IncludeSeconds, 3);
+            var from = GetInstant("2017-11-05 02:00:00 -05:00");
+
+            var first = expression.GetPreviousOccurrence(from, EasternTimeZone);
+            var second = expression.GetPreviousOccurrence(first!.Value, EasternTimeZone);
+            var third = expression.GetPreviousOccurrence(second!.Value, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-11-05 01:38:00 -05:00"), first);
+            Assert.Equal(GetInstant("2017-11-05 01:08:00 -05:00"), second);
+            Assert.Equal(GetInstant("2017-11-05 01:38:00 -04:00"), third);
+        }
+
+        [Fact]
         public void GetPreviousOccurrence_AdjustsInvalidTimeBackwardAcrossSpringForward()
         {
             var expression = CronExpression.Parse("30 2 * * *");
+            var from = GetInstant("2017-03-12 04:00:00 -04:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-03-12 01:59:59 -05:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_AdjustsInvalidHashTimeBackwardAcrossSpringForward()
+        {
+            var expression = CronExpression.Parse("0 H 2 * * *", CronFormat.IncludeSeconds, 3);
             var from = GetInstant("2017-03-12 04:00:00 -04:00");
 
             var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);


### PR DESCRIPTION
Addresses https://github.com/HangfireIO/Cronos/issues/67 
As mentioned in the issue, and as seen in the wild, people often do some sort of "look forward from a moment far enough in the past" 
This PR introduces the backward search as first class use case. 
The code tries as much as possible to mimic the forward case to keep symetry. 