### PR TITLE
Fix GetPreviousOccurrence for occurrences in the spring-forward gap

### DIFF
--- a/src/Cronos/CronExpression.cs
+++ b/src/Cronos/CronExpression.cs
@@ -767,35 +767,39 @@ namespace Cronos
                 }
             }
 
-            var occurrenceTicks = FindPreviousOccurrence(fromLocal.Ticks, inclusive);
-            if (occurrenceTicks == NotFound) return null;
-
-            var occurrence = new DateTime(occurrenceTicks, DateTimeKind.Unspecified);
-
-            if (zone.IsInvalidTime(occurrence))
+            while (true)
             {
-                var previousValidTime = TimeZoneHelper.GetStandardTimeEnd(zone, occurrence);
-                if (previousValidTime.Date < occurrence.Date)
+                var occurrenceTicks = FindPreviousOccurrence(fromLocal.Ticks, inclusive);
+                if (occurrenceTicks == NotFound) return null;
+
+                var occurrence = new DateTime(occurrenceTicks, DateTimeKind.Unspecified);
+
+                if (zone.IsInvalidTime(occurrence))
                 {
+                    // Occurrences scheduled to invalid time are shifted forward to the moment when daylight saving
+                    // time starts, exactly as GetNextOccurrence does, so both directions agree on the same instant.
                     var daylightTimeStart = TimeZoneHelper.GetDaylightTimeStart(zone, occurrence);
-                    return new DateTimeOffset(occurrence, daylightTimeStart.Offset);
+                    if (daylightTimeStart < fromUtc || (inclusive && daylightTimeStart == fromUtc)) return daylightTimeStart;
+
+                    // The shifted occurrence isn't in the past, so continue searching right before the invalid interval.
+                    fromLocal = TimeZoneHelper.GetStandardTimeEnd(zone, occurrence).DateTime;
+                    inclusive = true;
+                    continue;
                 }
 
-                return previousValidTime;
-            }
-
-            if (TimeZoneHelper.IsAmbiguousTime(zone, occurrence))
-            {
-                var daylightOffset = TimeZoneHelper.GetDaylightOffset(zone, occurrence);
-                if (HasFlag(CronExpressionFlag.Interval))
+                if (TimeZoneHelper.IsAmbiguousTime(zone, occurrence))
                 {
-                    return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
+                    var daylightOffset = TimeZoneHelper.GetDaylightOffset(zone, occurrence);
+                    if (HasFlag(CronExpressionFlag.Interval))
+                    {
+                        return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
+                    }
+
+                    return new DateTimeOffset(occurrence, daylightOffset);
                 }
 
-                return new DateTimeOffset(occurrence, daylightOffset);
+                return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
             }
-
-            return new DateTimeOffset(occurrence, zone.GetUtcOffset(occurrence));
         }
 
         private long FindOccurrence(long startTimeTicks, long endTimeTicks, bool startInclusive)

--- a/tests/Cronos.Tests/CronExpressionReverseFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionReverseFacts.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Xunit;
@@ -18,11 +19,13 @@ namespace Cronos.Tests
         private static readonly string JordanTimeZoneId = IsUnix ? "Asia/Amman" : "Jordan Standard Time";
         private static readonly string LordHoweTimeZoneId = IsUnix ? "Australia/Lord_Howe" : "Lord Howe Standard Time";
         private static readonly string PacificTimeZoneId = IsUnix ? "America/Santiago" : "Pacific SA Standard Time";
+        private static readonly string CentralEuropeanTimeZoneId = IsUnix ? "Europe/Berlin" : "W. Europe Standard Time";
 
         private static readonly TimeZoneInfo EasternTimeZone = TimeZoneInfo.FindSystemTimeZoneById(EasternTimeZoneId);
         private static readonly TimeZoneInfo JordanTimeZone = TimeZoneInfo.FindSystemTimeZoneById(JordanTimeZoneId);
         private static readonly TimeZoneInfo LordHoweTimeZone = TimeZoneInfo.FindSystemTimeZoneById(LordHoweTimeZoneId);
         private static readonly TimeZoneInfo PacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById(PacificTimeZoneId);
+        private static readonly TimeZoneInfo CentralEuropeanTimeZone = TimeZoneInfo.FindSystemTimeZoneById(CentralEuropeanTimeZoneId);
 
         [Theory]
         [InlineData(DateTimeKind.Unspecified, false)]
@@ -344,25 +347,108 @@ namespace Cronos.Tests
         }
 
         [Fact]
-        public void GetPreviousOccurrence_AdjustsInvalidTimeBackwardAcrossSpringForward()
+        public void GetPreviousOccurrence_ShiftsInvalidTimeForwardAcrossSpringForward()
         {
             var expression = CronExpression.Parse("30 2 * * *");
             var from = GetInstant("2017-03-12 04:00:00 -04:00");
 
             var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
 
-            Assert.Equal(GetInstant("2017-03-12 01:59:59 -05:00"), previous);
+            Assert.Equal(GetInstant("2017-03-12 03:00:00 -04:00"), previous);
         }
 
         [Fact]
-        public void GetPreviousOccurrence_AdjustsInvalidHashTimeBackwardAcrossSpringForward()
+        public void GetPreviousOccurrence_ShiftsInvalidHashTimeForwardAcrossSpringForward()
         {
             var expression = CronExpression.Parse("0 H 2 * * *", CronFormat.IncludeSeconds, 3);
             var from = GetInstant("2017-03-12 04:00:00 -04:00");
 
             var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
 
-            Assert.Equal(GetInstant("2017-03-12 01:59:59 -05:00"), previous);
+            Assert.Equal(GetInstant("2017-03-12 03:00:00 -04:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_SkipsInvalidTimeShiftedAfterFrom_AndReturnsEarlierOccurrence()
+        {
+            var expression = CronExpression.Parse("30 2 * * *");
+            var from = GetInstant("2017-03-12 01:59:59 -05:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-03-11 02:30:00 -05:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_ReturnsShiftedInvalidTime_WhenFromEqualsItAndInclusive()
+        {
+            var expression = CronExpression.Parse("30 2 * * *");
+            var from = GetInstant("2017-03-12 03:00:00 -04:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone, inclusive: true);
+
+            Assert.Equal(GetInstant("2017-03-12 03:00:00 -04:00"), previous);
+        }
+
+        [Fact]
+        public void GetPreviousOccurrence_SkipsShiftedInvalidTime_WhenFromEqualsItAndExclusive()
+        {
+            var expression = CronExpression.Parse("30 2 * * *");
+            var from = GetInstant("2017-03-12 03:00:00 -04:00");
+
+            var previous = expression.GetPreviousOccurrence(from, EasternTimeZone);
+
+            Assert.Equal(GetInstant("2017-03-11 02:30:00 -05:00"), previous);
+        }
+
+        [Theory]
+        [InlineData("30 2 * * *", "2024-04-01 02:30:00 +02:00", "2024-03-31 03:00:00 +02:00")]
+        [InlineData("30 2 * * *", "2024-03-31 03:00:00 +02:00", "2024-03-30 02:30:00 +01:00")]
+        public void GetPreviousOccurrence_MirrorsGetNextOccurrenceAcrossSpringForward(
+            string cronExpression, string fromString, string expectedString)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+            var from = GetInstant(fromString);
+
+            var previous = expression.GetPreviousOccurrence(from, CentralEuropeanTimeZone);
+
+            Assert.Equal(GetInstant(expectedString), previous);
+        }
+
+        [Theory]
+        [InlineData("30 2 * * *")]
+        [InlineData("0 2 * * *")]
+        [InlineData("0,30 1,2 * * *")]
+        [InlineData("*/10 2 * * *")]
+        [InlineData("* * * * *")]
+        [InlineData("*/30 * * * *")]
+        public void GetPreviousOccurrence_RetracesGetNextOccurrenceAroundSpringForward(string cronExpression)
+        {
+            var expression = CronExpression.Parse(cronExpression);
+            var zone = CentralEuropeanTimeZone;
+
+            var forward = new List<DateTimeOffset>();
+            var cursor = GetInstant("2024-03-29 00:00:00 +00:00");
+            var limit = GetInstant("2024-04-02 00:00:00 +00:00");
+
+            for (var next = expression.GetNextOccurrence(cursor, zone);
+                 next != null && next.Value <= limit;
+                 next = expression.GetNextOccurrence(next.Value, zone))
+            {
+                forward.Add(next.Value);
+            }
+
+            Assert.True(forward.Count > 2, "expected the forward walk to produce occurrences");
+
+            var backward = new List<DateTimeOffset>();
+            for (var previous = expression.GetPreviousOccurrence(forward[forward.Count - 1], zone);
+                 previous != null && backward.Count < forward.Count - 1;
+                 previous = expression.GetPreviousOccurrence(previous.Value, zone))
+            {
+                backward.Insert(0, previous.Value);
+            }
+
+            Assert.Equal(forward.Take(forward.Count - 1), backward);
         }
 
         [Theory]


### PR DESCRIPTION
## Problem

`GetNextOccurrence` and `GetPreviousOccurrence` disagree about occurrences that fall into the gap skipped when the clock jumps forward to daylight saving time.

`GetNextOccurrence` shifts such an occurrence **forward** to the moment DST starts (documented in the README: `Mar 14, 03:00 +04:00 – run (adjusted)`). `GetPreviousOccurrence` shifted it **backward** to the last valid second before the gap — a second that isn't an occurrence of the expression at all.

Reproducing #92 with `30 2 * * *` in W. Europe Standard Time around the 2024-03-31 transition:

| Direction | Local (NL) |
|---|---|
| `GetNextOccurrence` | `2024-03-31 03:00:00 +02:00` |
| `GetPreviousOccurrence` (before the fix) | `2024-03-31 01:59:59 +01:00` |

So walking a schedule backwards does not retrace the forward sequence, and `GetOccurrences` disagrees with itself depending on direction.

This isn't specific to one zone or expression. Using forward enumeration as the oracle and probing every minute in a ±26h window around every DST transition from 2017–2025, the pre-fix code mismatches in **12 distinct (zone, expression, inclusive/exclusive) groups** — `Europe/Berlin`, `America/New_York`, `Australia/Lord_Howe`, `Pacific/Chatham`, `America/Santiago`, `America/Sao_Paulo` — and every one of them sits on a spring-forward transition.

## Fix

`GetPreviousOccurrenceConsideringTimeZone` now shifts an invalid-time occurrence forward to the start of DST, exactly as `GetNextOccurrence` does.

Because that shifted instant can land at or after the requested `from`, the search loops and continues right before the invalid interval when that happens — so `GetPreviousOccurrence` still never returns a value later than `from`. Both the inclusive and exclusive boundaries at the shifted instant are covered by tests.

Two existing tests asserted the old backward-shift behaviour and are updated to the mirrored expectation; they were the encoding of this bug:

- `GetPreviousOccurrence_AdjustsInvalidTimeBackwardAcrossSpringForward` → `..._ShiftsInvalidTimeForwardAcrossSpringForward`
- `GetPreviousOccurrence_AdjustsInvalidHashTimeBackwardAcrossSpringForward` → `..._ShiftsInvalidHashTimeForwardAcrossSpringForward`

## How to test

```
dotnet test tests/Cronos.Tests/Cronos.Tests.csproj -f net8.0
```

Result on this branch: **1867 passed, 12 failed**. All 12 failures are the pre-existing `Asia/Amman` tzdb-dependent failures already tracked in #91 — they fail identically on unmodified `main` on this machine, are all `GetNextOccurrence` tests, and none are touched by this change.

New tests (9 added, 2 updated, all passing):

- `GetPreviousOccurrence_ShiftsInvalidTimeForwardAcrossSpringForward` / `..._ShiftsInvalidHashTimeForwardAcrossSpringForward`
- `GetPreviousOccurrence_SkipsInvalidTimeShiftedAfterFrom_AndReturnsEarlierOccurrence` — the "shifted occurrence isn't in the past" path
- `GetPreviousOccurrence_ReturnsShiftedInvalidTime_WhenFromEqualsItAndInclusive` / `..._SkipsShiftedInvalidTime_WhenFromEqualsItAndExclusive` — boundary behaviour
- `GetPreviousOccurrence_MirrorsGetNextOccurrenceAcrossSpringForward` — the exact instants from #92
- `GetPreviousOccurrence_RetracesGetNextOccurrenceAroundSpringForward` — 6 expressions, walks forward across the 2024-03-31 transition then walks back and asserts the sequences agree

Beyond the suite, an out-of-tree harness probed **7,321,866** `GetPreviousOccurrence` calls (6 zones × 13 expressions × every DST transition 2017–2025 × every minute in ±26h × inclusive and exclusive) against forward enumeration as ground truth: **0 mismatches** after the fix, 12 mismatching groups before it.

`Asia/Amman` is excluded from that harness because `GetNextOccurrence` — the oracle — is itself wrong there on a Linux tzdb (it returns the same instant repeatedly with an offset that contradicts `TimeZoneInfo.GetUtcOffset`). That is the pre-existing behaviour behind #91 and is out of scope here.

## Platforms tested

Linux (arm64, .NET 10 SDK) fully verified on `net8.0` and `net6.0` — identical results. `net462` requires Mono and was not run; the change uses no new APIs and no platform-specific primitives (only existing `TimeZoneHelper` members already used by the forward path).

Related: #91 — independent, pre-existing `Asia/Amman` tzdb failures in `GetNextOccurrence`, not affected by this change.
