### PR TITLE
Fix reversed day-of-week range starting at 7 never firing

### DIFF
--- a/src/Cronos/CronParser.cs
+++ b/src/Cronos/CronParser.cs
@@ -500,6 +500,12 @@ namespace Cronos
             // Skip one of the Sundays.
             if (field == CronField.DaysOfWeek) high--;
 
+            // 7 and 0 both mean Sunday, so a reversed day-of-week range that starts
+            // at 7 (e.g. 7-1) is the same as the forward range from 0. Without this
+            // the range below iterates GetRangeBits(7, 6, ...) which is empty and a
+            // negative modulo corrupts the phase, dropping Sunday (7-1/2 never fires).
+            if (field == CronField.DaysOfWeek && num1 > high) return GetRangeBits(field.First, num2, step);
+
             var bits = GetRangeBits(num1, high, step);
             
             num1 = field.First + step - (high - num1) % step - 1;

--- a/tests/Cronos.Tests/CronExpressionFacts.cs
+++ b/tests/Cronos.Tests/CronExpressionFacts.cs
@@ -1148,6 +1148,22 @@ namespace Cronos.Tests
             Assert.Equal(GetInstantFromLocalTime(expectedString, EasternTimeZone), occurrence);
         }
 
+        [Fact]
+        public void GetNextOccurrence_HandlesReversedDayOfWeekRangeStartingAtSeven()
+        {
+            // 7 and 0 both mean Sunday, so 7-1/2 must behave like 0-1/2 and fire
+            // on Sundays -- it used to compile to a schedule that never fired.
+            var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var seven = CronExpression.Parse("0 0 * * 7-1/2", CronFormat.Standard);
+            var zero = CronExpression.Parse("0 0 * * 0-1/2", CronFormat.Standard);
+
+            var occurrence = seven.GetNextOccurrence(from, TimeZoneInfo.Utc, inclusive: false);
+
+            Assert.NotNull(occurrence);
+            Assert.Equal(DayOfWeek.Sunday, occurrence.Value.DayOfWeek);
+            Assert.Equal(zero.GetNextOccurrence(from, TimeZoneInfo.Utc, inclusive: false), occurrence);
+        }
+
         [Theory]
         [InlineData(true, 00001)]
         [InlineData(true, 09999)]


### PR DESCRIPTION
`7` and `0` both mean Sunday, so a reversed day-of-week range starting at `7` (e.g. `7-1/2`) should behave like the forward range from `0` (`0-1/2`). It didn't: `GetReversedRangeBits` decrements `high` to 6 to skip the duplicate Sunday, but with `num1 == 7` that makes `GetRangeBits(7, 6, step)` iterate empty and the follow-up `(6 - 7) % step` goes negative, corrupting the phase. Sunday is dropped, and short ranges compile to a schedule that **never fires** — `GetNextOccurrence` returns `null` forever for `0 0 * * 7-1/2`.

Fix: when a reversed day-of-week range starts at `7`, treat it as the forward range from `First`. Verified `7-1/2` and `7-3/2` now match `0-1/2` / `0-3/2` exactly; normal reversed ranges (`5-2`), all-week (`1-7`), and `7-7` are unaffected, and the existing suite stays green.
